### PR TITLE
Use Mambaforge to install mamba/conda

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,17 +46,16 @@ RUN script=$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-
 ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
 CMD [ "sleep", "infinity" ]
 
-ARG MAMBA_VERSION=0.22.1
+ARG MAMBAFORGE_VERSION=22.9.0-2
 
-# Based on https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile.
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
-    && mkdir -p /opt \
-    && bash miniconda.sh -b -p /opt/conda \
-    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
-    && find /opt/conda/ -follow -type f -name '*.a' -delete \
-    && find /opt/conda/ -follow -type f -name '*.js.map' -delete \
-    && /opt/conda/bin/conda install -n base -c conda-forge mamba=${MAMBA_VERSION} \
-    && /opt/conda/bin/conda clean -afy \
+# Based on https://github.com/conda-forge/miniforge-images/blob/master/ubuntu/Dockerfile
+RUN wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MAMBAFORGE_VERSION}/Mambaforge-${MAMBAFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh \
+    && /bin/bash /tmp/miniforge.sh -b -p /opt/conda \
+    && rm /tmp/miniforge.sh \
+    && /opt/conda/bin/conda clean --tarballs --index-cache --packages --yes \
+    && find /opt/conda -follow -type f -name '*.a' -delete \
+    && find /opt/conda -follow -type f -name '*.pyc' -delete \
+    && /opt/conda/bin/conda clean --force-pkgs-dirs --all --yes  \
     && groupadd -r conda --gid ${CONDA_GID} \
     && usermod -aG conda ${USERNAME} \
     && chown -R :conda /opt/conda \
@@ -95,3 +94,4 @@ RUN wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_
     && tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && mv yardl "/opt/conda/envs/${CONDA_ENVIRONMENT_NAME}/bin/" \
     && rm "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
+    


### PR DESCRIPTION
The way we were installing mamba is no longer recommended and we were encountering conflicts with the version of conda we were installing. We were also running out of system resources building the devcontainer image in 2-core Codespaces VM, which is the default. This change should address both issues.

Addresses #1 